### PR TITLE
Remove minlength validation from title and subtitle fields

### DIFF
--- a/src/content/function/open-graph-image-generator-v2/test.njk
+++ b/src/content/function/open-graph-image-generator-v2/test.njk
@@ -68,11 +68,9 @@
         <h2 class="text-xl inline m-0 p1">Test how it works</h2>
       </legend>
       <label for="title">Type any text as a title:</label>
-      <input type="text" id="title" name="title" x-model="title"
-             minlength="10" placeholder="Hello World!">
+      <input type="text" id="title" name="title" x-model="title" placeholder="Hello World!">
       <label for="subtitle">Type any text as a subtitle:</label>
-      <input type="text" id="subtitle" name="subtitle" x-model="subtitle"
-             minlength="10" placeholder="example.com">
+      <input type="text" id="subtitle" name="subtitle" x-model="subtitle" placeholder="example.com">
     </fieldset>
     <input type="submit" :value="submitButton" value="Generate image">
   </form>


### PR DESCRIPTION
The commit removes the minlength attribute from the title and subtitle input fields in the open graph image generator form. This change allows the user to enter text of any length. Previously, the input fields required at least 10 characters.